### PR TITLE
Include curl command for mac users

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,14 +81,18 @@ This kills the auto update script so that you can make changes, or copy your 802
   mount -o remount,rw /dev/ubi0 /  
   mount mtd:mfg -t jffs2 /mfg
   cp /mfg/mfg.dat /www/att/mfg.dat
-  Download: http://192.168.1.254/mfg.dat
+  Download:
+  - http://192.168.1.254/mfg.dat
+  - mac user: curl http://192.168.1.254/mfg.dat -o mfg.dat
   
   ## Next:
   
   cd /tmp
   tar cf cert.tar /etc/rootcert/
   cp cert.tar /www/att/images
-  Download: http://192.168.1.254/images/cert.tar
+  Download:
+  - http://192.168.1.254/images/cert.tar
+  - mac user: curl http://192.168.1.254/cert.tar -o cert.tar
   ```
 - Reminder: Download http://192.168.1.254/mfg.dat and http://192.168.1.254/images/cert.tar to your **local** device.
 


### PR DESCRIPTION
Feel free to change the formatting, but I thought I'd include some commands for a mac user as hitting the mfg.dat file in a web browser on a mac doesn't give you the option for right-click save-file-as option in certain web browsers.